### PR TITLE
refactor: Convert housing-data-poc to proper Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "housing-data-poc"]
+	path = housing-data-poc
+	url = https://github.com/chrischaps/HousingData-POC.git


### PR DESCRIPTION
- Create separate GitHub repository: HousingData-POC
- Configure housing-data-poc as proper submodule
- Link to https://github.com/chrischaps/HousingData-POC.git

POC code now has its own repository and is properly tracked as a submodule rather than an embedded git repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)