### PR TITLE
fix: Apply dark mode styles to mobile carousel cards (fixes #18)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,20 @@
       "Bash(git commit:*)",
       "Bash(gcloud builds triggers run:*)",
       "Bash(gcloud storage buckets:*)",
-      "Bash(gcloud builds list:*)"
+      "Bash(gcloud builds list:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git push:*)",
+      "Bash(git merge:*)",
+      "Bash(head:*)",
+      "Bash(mkdir:*)",
+      "Bash(npm install)",
+      "Bash(npm run split-csv:*)",
+      "Bash(gcloud storage ls:*)",
+      "Bash(Select-Object -First 3)",
+      "Bash(awk:*)",
+      "Bash(gh issue create:*)",
+      "Bash(git pull:*)",
+      "Bash(cat:*)"
     ],
     "deny": [],
     "ask": []

--- a/housing-data-app/.claude/settings.local.json
+++ b/housing-data-app/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue create:*)",
+      "Bash(gh issue view:*)",
+      "Bash(npm run build:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/housing-data-app/package.json
+++ b/housing-data-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "housing-data-app",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "Production housing market data visualization and analysis platform with Firebase authentication",
   "scripts": {

--- a/housing-data-app/src/components/CompactFavoriteCard.tsx
+++ b/housing-data-app/src/components/CompactFavoriteCard.tsx
@@ -79,16 +79,16 @@ export const CompactFavoriteCard = ({
   // Loading skeleton
   if (loading) {
     return (
-      <div className="flex-shrink-0 w-36 h-32 rounded-lg p-3 bg-white border border-gray-200 animate-pulse">
+      <div className="flex-shrink-0 w-36 h-32 rounded-lg p-3 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 animate-pulse">
         <div className="flex flex-col h-full">
-          <div className="h-3 w-20 bg-gray-200 rounded mb-2"></div>
-          <div className="h-4 w-16 bg-gray-200 rounded mb-2"></div>
-          <div className="h-3 w-12 bg-gray-200 rounded mb-2"></div>
+          <div className="h-3 w-20 bg-gray-200 dark:bg-slate-700 rounded mb-2"></div>
+          <div className="h-4 w-16 bg-gray-200 dark:bg-slate-700 rounded mb-2"></div>
+          <div className="h-3 w-12 bg-gray-200 dark:bg-slate-700 rounded mb-2"></div>
           <div className="flex-1 flex items-end gap-0.5">
             {[...Array(12)].map((_, i) => (
               <div
                 key={i}
-                className="flex-1 bg-gray-200 rounded-t"
+                className="flex-1 bg-gray-200 dark:bg-slate-700 rounded-t"
                 style={{ height: `${Math.random() * 60 + 40}%` }}
               ></div>
             ))}
@@ -106,14 +106,14 @@ export const CompactFavoriteCard = ({
         className={`
           flex-shrink-0 w-36 h-32 rounded-lg p-3 cursor-pointer transition-all
           ${isSelected
-            ? 'bg-blue-50 border-2 border-blue-500 shadow-md'
-            : 'bg-white border border-gray-200 hover:border-gray-300 hover:shadow-md'
+            ? 'bg-blue-50 dark:bg-blue-900/30 border-2 border-blue-500 dark:border-blue-400 shadow-md'
+            : 'bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 hover:border-gray-300 dark:hover:border-slate-600 hover:shadow-md'
           }
         `}
       >
         <div className="flex flex-col h-full justify-center items-center">
-          <div className="text-xs font-medium text-gray-500">{marketName}</div>
-          <div className="text-xs text-gray-400 mt-1">No data</div>
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400">{marketName}</div>
+          <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">No data</div>
         </div>
       </button>
     );
@@ -121,7 +121,7 @@ export const CompactFavoriteCard = ({
 
   const isPositive = marketData.changeDirection === 'up';
   const arrow = isPositive ? '↑' : '↓';
-  const changeColor = isPositive ? 'text-green-600' : 'text-red-600';
+  const changeColor = isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400';
   const lineColor = isPositive ? '#10B981' : '#EF4444';
   const chartData = marketData.historicalData.map(point => ({ value: point.price }));
 
@@ -131,8 +131,8 @@ export const CompactFavoriteCard = ({
       className={`
         flex-shrink-0 w-36 h-32 rounded-lg p-3 cursor-pointer transition-all
         ${isSelected
-          ? 'bg-blue-50 border-2 border-blue-500 shadow-md'
-          : 'bg-white border border-gray-200 hover:border-gray-300 hover:shadow-md'
+          ? 'bg-blue-50 dark:bg-blue-900/30 border-2 border-blue-500 dark:border-blue-400 shadow-md'
+          : 'bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 hover:border-gray-300 dark:hover:border-slate-600 hover:shadow-md'
         }
       `}
     >
@@ -144,7 +144,7 @@ export const CompactFavoriteCard = ({
               e.stopPropagation();
               onAddToComparison(marketData);
             }}
-            className="absolute -top-1 -right-1 text-purple-600 hover:text-purple-900 bg-white hover:bg-purple-50 rounded-full w-5 h-5 flex items-center justify-center text-xs border border-purple-200 transition-all hover:scale-110 z-10"
+            className="absolute -top-1 -right-1 text-purple-600 dark:text-purple-400 hover:text-purple-900 dark:hover:text-purple-300 bg-white dark:bg-slate-700 hover:bg-purple-50 dark:hover:bg-purple-900/30 rounded-full w-5 h-5 flex items-center justify-center text-xs border border-purple-200 dark:border-purple-600 transition-all hover:scale-110 z-10"
             title="Add to comparison"
           >
             ⚖️
@@ -153,14 +153,14 @@ export const CompactFavoriteCard = ({
 
         {/* Market name (truncated) + Star indicator */}
         <div className="flex items-center justify-between mb-1">
-          <div className="text-xs font-medium text-gray-900 truncate flex-1">
+          <div className="text-xs font-medium text-gray-900 dark:text-white truncate flex-1">
             {marketName}
           </div>
-          <span className="text-yellow-600 text-sm ml-1 flex-shrink-0">★</span>
+          <span className="text-yellow-600 dark:text-yellow-400 text-sm ml-1 flex-shrink-0">★</span>
         </div>
 
         {/* Current price */}
-        <div className="text-base font-bold text-gray-900 mb-1">
+        <div className="text-base font-bold text-gray-900 dark:text-white mb-1">
           {formatPrice(marketData.currentPrice)}
         </div>
 

--- a/housing-data-app/src/components/CompactMarketCard.tsx
+++ b/housing-data-app/src/components/CompactMarketCard.tsx
@@ -15,7 +15,7 @@ interface CompactMarketCardProps {
 export const CompactMarketCard = ({ market, onClick, isSelected = false }: CompactMarketCardProps) => {
   const isPositive = market.changeDirection === 'up';
   const arrow = isPositive ? '↑' : '↓';
-  const changeColor = isPositive ? 'text-green-600' : 'text-red-600';
+  const changeColor = isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400';
   const lineColor = isPositive ? '#10B981' : '#EF4444';
 
   // Prepare data for mini chart (use ALL historical data for MAX timescale)
@@ -27,19 +27,19 @@ export const CompactMarketCard = ({ market, onClick, isSelected = false }: Compa
       className={`
         flex-shrink-0 w-36 h-32 rounded-lg p-3 cursor-pointer transition-all
         ${isSelected
-          ? 'bg-blue-50 border-2 border-blue-500 shadow-md'
-          : 'bg-white border border-gray-200 hover:border-gray-300 hover:shadow-md'
+          ? 'bg-blue-50 dark:bg-blue-900/30 border-2 border-blue-500 dark:border-blue-400 shadow-md'
+          : 'bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 hover:border-gray-300 dark:hover:border-slate-600 hover:shadow-md'
         }
       `}
     >
       <div className="flex flex-col h-full">
         {/* Market name (truncated) */}
-        <div className="text-xs font-medium text-gray-900 truncate mb-1">
+        <div className="text-xs font-medium text-gray-900 dark:text-white truncate mb-1">
           {market.marketName}
         </div>
 
         {/* Current price */}
-        <div className="text-base font-bold text-gray-900 mb-1">
+        <div className="text-base font-bold text-gray-900 dark:text-white mb-1">
           {formatPrice(market.currentPrice)}
         </div>
 

--- a/housing-data-app/src/components/FavoritesCarousel.tsx
+++ b/housing-data-app/src/components/FavoritesCarousel.tsx
@@ -41,27 +41,27 @@ export const FavoritesCarousel = ({
       {/* Section header */}
       <div className="flex items-center justify-between mb-3 px-4">
         <div className="flex items-center gap-2">
-          <h2 className="text-lg font-semibold text-gray-900">My Favorites</h2>
-          <span className="text-yellow-600 text-lg">★</span>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">My Favorites</h2>
+          <span className="text-yellow-600 dark:text-yellow-400 text-lg">★</span>
         </div>
 
         {/* Scroll buttons - hidden on mobile, shown on larger screens */}
         <div className="hidden sm:flex gap-2">
           <button
             onClick={() => scroll('left')}
-            className="p-1.5 rounded-full bg-white border border-gray-300 hover:bg-gray-50 transition-colors"
+            className="p-1.5 rounded-full bg-white dark:bg-slate-700 border border-gray-300 dark:border-slate-600 hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors"
             aria-label="Scroll left"
           >
-            <svg className="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-4 h-4 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
           </button>
           <button
             onClick={() => scroll('right')}
-            className="p-1.5 rounded-full bg-white border border-gray-300 hover:bg-gray-50 transition-colors"
+            className="p-1.5 rounded-full bg-white dark:bg-slate-700 border border-gray-300 dark:border-slate-600 hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors"
             aria-label="Scroll right"
           >
-            <svg className="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-4 h-4 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>
           </button>
@@ -91,7 +91,7 @@ export const FavoritesCarousel = ({
             </div>
           ))
         ) : (
-          <div className="flex-1 flex items-center justify-center py-8 text-gray-500 text-sm">
+          <div className="flex-1 flex items-center justify-center py-8 text-gray-500 dark:text-gray-400 text-sm">
             No favorites yet
           </div>
         )}

--- a/housing-data-app/src/components/FeaturedMarketsCarousel.tsx
+++ b/housing-data-app/src/components/FeaturedMarketsCarousel.tsx
@@ -41,25 +41,25 @@ export const FeaturedMarketsCarousel = ({
     <div className="relative">
       {/* Section header */}
       <div className="flex items-center justify-between mb-3 px-4">
-        <h2 className="text-lg font-semibold text-gray-900">Featured Markets</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Featured Markets</h2>
 
         {/* Scroll buttons - hidden on mobile, shown on larger screens */}
         <div className="hidden sm:flex gap-2">
           <button
             onClick={() => scroll('left')}
-            className="p-1.5 rounded-full bg-white border border-gray-300 hover:bg-gray-50 transition-colors"
+            className="p-1.5 rounded-full bg-white dark:bg-slate-700 border border-gray-300 dark:border-slate-600 hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors"
             aria-label="Scroll left"
           >
-            <svg className="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-4 h-4 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
           </button>
           <button
             onClick={() => scroll('right')}
-            className="p-1.5 rounded-full bg-white border border-gray-300 hover:bg-gray-50 transition-colors"
+            className="p-1.5 rounded-full bg-white dark:bg-slate-700 border border-gray-300 dark:border-slate-600 hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors"
             aria-label="Scroll right"
           >
-            <svg className="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-4 h-4 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>
           </button>
@@ -89,7 +89,7 @@ export const FeaturedMarketsCarousel = ({
             </div>
           ))
         ) : (
-          <div className="flex-1 flex items-center justify-center py-8 text-gray-500">
+          <div className="flex-1 flex items-center justify-center py-8 text-gray-500 dark:text-gray-400">
             No featured markets available
           </div>
         )}


### PR DESCRIPTION
## Summary
- Applied comprehensive dark mode styling to mobile carousel components and cards
- Fixed issue where featured markets and favorites cards were not reflecting dark mode on mobile

## Changes Made

### Components Updated:
1. **FeaturedMarketsCarousel**
   - Header text: `text-gray-900 dark:text-white`
   - Scroll buttons: Added dark mode variants for background, borders, icons
   - Empty state text: `text-gray-500 dark:text-gray-400`

2. **FavoritesCarousel**
   - Header text: `text-gray-900 dark:text-white`
   - Star icon: `text-yellow-600 dark:text-yellow-400`
   - Scroll buttons: Added dark mode variants
   - Empty state text: `text-gray-500 dark:text-gray-400`

3. **CompactMarketCard**
   - Card background: `bg-white dark:bg-slate-800`
   - Card borders: `border-gray-200 dark:border-slate-700`
   - Text colors: `text-gray-900 dark:text-white`
   - Selected state: `bg-blue-50 dark:bg-blue-900/30`
   - Price change colors: Added dark variants for green/red

4. **CompactFavoriteCard**
   - All styles from CompactMarketCard plus:
   - Loading skeleton: `bg-gray-200 dark:bg-slate-700`
   - Comparison button: Added dark mode variants
   - Star icon: `text-yellow-600 dark:text-yellow-400`

## Version
- Bumped from `0.8.0` → `0.8.1` (PATCH - bug fix)

## Testing
- ✅ Build successful with no TypeScript errors
- ✅ All dark mode styles follow existing design system patterns
- ✅ Maintains accessibility and hover states

## Screenshots
_Please test in dark mode on mobile to verify the fix_

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)