### PR TITLE
fix: Add compare button to featured market cards on mobile (fixes #5)

### DIFF
--- a/housing-data-app/package.json
+++ b/housing-data-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "housing-data-app",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "Production housing market data visualization and analysis platform with Firebase authentication",
   "scripts": {

--- a/housing-data-app/src/App.tsx
+++ b/housing-data-app/src/App.tsx
@@ -380,6 +380,7 @@ function App() {
               markets={marketData}
               selectedMarketId={selectedMarket?.marketId}
               onSelectMarket={handleMarketClick}
+              onAddToComparison={handleAddToComparison}
               loading={dataLoading}
             />
           )}

--- a/housing-data-app/src/components/CompactMarketCard.tsx
+++ b/housing-data-app/src/components/CompactMarketCard.tsx
@@ -6,13 +6,14 @@ interface CompactMarketCardProps {
   market: MarketPriceData;
   onClick: () => void;
   isSelected?: boolean;
+  onAddToComparison?: (market: MarketPriceData) => void;
 }
 
 /**
  * Compact market card with mini sparkline chart for carousel display
  * Optimized for mobile horizontal scrolling (Google Finance style)
  */
-export const CompactMarketCard = ({ market, onClick, isSelected = false }: CompactMarketCardProps) => {
+export const CompactMarketCard = ({ market, onClick, isSelected = false, onAddToComparison }: CompactMarketCardProps) => {
   const isPositive = market.changeDirection === 'up';
   const arrow = isPositive ? '↑' : '↓';
   const changeColor = isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400';
@@ -32,7 +33,21 @@ export const CompactMarketCard = ({ market, onClick, isSelected = false }: Compa
         }
       `}
     >
-      <div className="flex flex-col h-full">
+      <div className="flex flex-col h-full relative">
+        {/* Comparison button - top right corner */}
+        {onAddToComparison && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onAddToComparison(market);
+            }}
+            className="absolute -top-1 -right-1 text-purple-600 dark:text-purple-400 hover:text-purple-900 dark:hover:text-purple-300 bg-white dark:bg-slate-700 hover:bg-purple-50 dark:hover:bg-purple-900/30 rounded-full w-5 h-5 flex items-center justify-center text-xs border border-purple-200 dark:border-purple-600 transition-all hover:scale-110 z-10"
+            title="Add to comparison"
+          >
+            ⚖️
+          </button>
+        )}
+
         {/* Market name (truncated) */}
         <div className="text-xs font-medium text-gray-900 dark:text-white truncate mb-1">
           {market.marketName}

--- a/housing-data-app/src/components/FeaturedMarketsCarousel.tsx
+++ b/housing-data-app/src/components/FeaturedMarketsCarousel.tsx
@@ -7,6 +7,7 @@ interface FeaturedMarketsCarouselProps {
   markets: MarketPriceData[];
   selectedMarketId?: string;
   onSelectMarket: (market: MarketPriceData) => void;
+  onAddToComparison?: (market: MarketPriceData) => void;
   loading?: boolean;
 }
 
@@ -18,6 +19,7 @@ export const FeaturedMarketsCarousel = ({
   markets,
   selectedMarketId,
   onSelectMarket,
+  onAddToComparison,
   loading = false,
 }: FeaturedMarketsCarouselProps) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -85,6 +87,7 @@ export const FeaturedMarketsCarousel = ({
                 market={market}
                 onClick={() => onSelectMarket(market)}
                 isSelected={market.marketId === selectedMarketId}
+                onAddToComparison={onAddToComparison}
               />
             </div>
           ))


### PR DESCRIPTION
## Summary
Added comparison functionality to featured market cards on mobile, achieving parity with favorites cards.

## Problem
Users could compare favorites to the current market, but featured market cards were missing the compare button on mobile view.

## Solution
Added a comparison button (⚖️) to featured market cards with identical UX to favorites cards.

## Changes

### 1. CompactMarketCard Component
- **New Prop**: `onAddToComparison?: (market: MarketPriceData) => void`
- **Comparison Button**: 
  - Positioned in top-right corner (absolute positioning)
  - Purple-themed to match comparison panel
  - Prevents event propagation (doesn't trigger card selection)
  - Hover effects with scale animation
  - Full dark mode support
- **Layout Update**: Changed container to `relative` to support absolute positioning

### 2. FeaturedMarketsCarousel Component
- **New Prop**: `onAddToComparison?: (market: MarketPriceData) => void`
- **Callback Forwarding**: Passes comparison callback to each CompactMarketCard
- **Backward Compatible**: Optional prop maintains existing functionality

### 3. App.tsx Integration
- **Connected Callback**: `handleAddToComparison` now passed to FeaturedMarketsCarousel
- **Consistent Logic**: Uses same comparison logic as favorites
- **Validation**: Prevents duplicates, checks limits (max 5 markets)

## Technical Details

### Button Styling
```tsx
className="absolute -top-1 -right-1 
  text-purple-600 dark:text-purple-400 
  hover:text-purple-900 dark:hover:text-purple-300 
  bg-white dark:bg-slate-700 
  hover:bg-purple-50 dark:hover:bg-purple-900/30 
  rounded-full w-5 h-5 
  border border-purple-200 dark:border-purple-600 
  transition-all hover:scale-110 z-10"
```

### Event Handling
- Uses `e.stopPropagation()` to prevent card click
- Calls `onAddToComparison(market)` with full market data
- Identical to CompactFavoriteCard implementation

## UX Flow
1. User taps ⚖️ button on featured market card
2. Market is added to comparison array (if valid)
3. Comparison panel displays below chart
4. Chart overlays all compared markets
5. User can remove markets individually or clear all

## Testing
- [x] Build successful with no TypeScript errors
- [x] Compare button appears on all featured market cards
- [x] Button doesn't trigger card selection
- [x] Markets successfully added to comparison
- [x] Validation works (max 5, no duplicates, not current market)
- [x] Dark mode styling correct
- [x] Matches favorites card UX

## Version
- Bumped from `0.9.0` → `0.9.1` (PATCH - bug fix)

## Screenshots
_Compare button now visible on featured market cards (top-right corner with ⚖️ icon)_

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)