### PR TITLE
fix: Wait for favorites to load before pre-selecting market (fixes #3)

### DIFF
--- a/housing-data-app/package.json
+++ b/housing-data-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "housing-data-app",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "description": "Production housing market data visualization and analysis platform with Firebase authentication",
   "scripts": {

--- a/housing-data-app/src/App.tsx
+++ b/housing-data-app/src/App.tsx
@@ -107,9 +107,15 @@ function App() {
       favoritesCount: favorites.length
     });
 
-    // Only run when data is loaded, favorites are loaded (if user is logged in), and no market is selected yet
+    // Only run when data is loaded, auth is loaded, favorites are loaded, and no market is selected yet
     if (dataLoading || selectedMarket) {
       console.log('[App] Early return - dataLoading or market already selected');
+      return;
+    }
+
+    // Wait for auth to initialize before making any selection decisions
+    if (authLoading) {
+      console.log('[App] Waiting for auth to initialize before pre-selecting market...');
       return;
     }
 
@@ -120,6 +126,12 @@ function App() {
     }
 
     const selectInitialMarket = async () => {
+      console.log('[App] selectInitialMarket() executing:', {
+        hasUser: !!user,
+        favoritesCount: favorites.length,
+        marketDataCount: marketData.length
+      });
+
       // If user is logged in and has favorites, select first favorite
       if (user && favorites.length > 0) {
         const firstFavorite = favorites[0];
@@ -168,6 +180,7 @@ function App() {
 
       // Otherwise, select first featured market
       if (marketData.length > 0) {
+        console.log('[App] No user or no favorites - selecting first featured market:', marketData[0].marketName);
         setSelectedMarket(marketData[0]);
       }
     };

--- a/housing-data-app/src/App.tsx
+++ b/housing-data-app/src/App.tsx
@@ -83,10 +83,35 @@ function App() {
   // Favorites hook
   const { favorites, loading: favoritesLoading, toggleFavorite, isFavorited } = useFavorites();
 
+  // Debug: Log state changes to diagnose pre-selection issue
+  useEffect(() => {
+    console.log('[App] State changed:', {
+      user: user?.email || 'not logged in',
+      authLoading,
+      dataLoading,
+      favoritesLoading,
+      selectedMarket: selectedMarket?.marketName || 'none',
+      favoritesCount: favorites.length,
+      marketDataCount: marketData.length
+    });
+  }, [user, authLoading, dataLoading, favoritesLoading, selectedMarket, favorites.length, marketData.length]);
+
   // Pre-selection logic: Select first favorite (if logged in with favorites) or first featured market
   useEffect(() => {
+    console.log('[App] Pre-selection effect running. Conditions:', {
+      dataLoading,
+      authLoading,
+      favoritesLoading,
+      selectedMarket: selectedMarket?.marketName || 'none',
+      user: user?.email || 'not logged in',
+      favoritesCount: favorites.length
+    });
+
     // Only run when data is loaded, favorites are loaded (if user is logged in), and no market is selected yet
-    if (dataLoading || selectedMarket) return;
+    if (dataLoading || selectedMarket) {
+      console.log('[App] Early return - dataLoading or market already selected');
+      return;
+    }
 
     // If user is logged in, wait for favorites to load before selecting
     if (user && favoritesLoading) {

--- a/housing-data-app/src/App.tsx
+++ b/housing-data-app/src/App.tsx
@@ -83,54 +83,19 @@ function App() {
   // Favorites hook
   const { favorites, loading: favoritesLoading, toggleFavorite, isFavorited } = useFavorites();
 
-  // Debug: Log state changes to diagnose pre-selection issue
-  useEffect(() => {
-    console.log('[App] State changed:', {
-      user: user?.email || 'not logged in',
-      authLoading,
-      dataLoading,
-      favoritesLoading,
-      selectedMarket: selectedMarket?.marketName || 'none',
-      favoritesCount: favorites.length,
-      marketDataCount: marketData.length
-    });
-  }, [user, authLoading, dataLoading, favoritesLoading, selectedMarket, favorites.length, marketData.length]);
-
   // Pre-selection logic: Select first favorite (if logged in with favorites) or first featured market
   useEffect(() => {
-    console.log('[App] Pre-selection effect running. Conditions:', {
-      dataLoading,
-      authLoading,
-      favoritesLoading,
-      selectedMarket: selectedMarket?.marketName || 'none',
-      user: user?.email || 'not logged in',
-      favoritesCount: favorites.length
-    });
 
     // Only run when data is loaded, auth is loaded, favorites are loaded, and no market is selected yet
-    if (dataLoading || selectedMarket) {
-      console.log('[App] Early return - dataLoading or market already selected');
-      return;
-    }
+    if (dataLoading || selectedMarket) return;
 
     // Wait for auth to initialize before making any selection decisions
-    if (authLoading) {
-      console.log('[App] Waiting for auth to initialize before pre-selecting market...');
-      return;
-    }
+    if (authLoading) return;
 
     // If user is logged in, wait for favorites to load before selecting
-    if (user && favoritesLoading) {
-      console.log('[App] Waiting for favorites to load before pre-selecting market...');
-      return;
-    }
+    if (user && favoritesLoading) return;
 
     const selectInitialMarket = async () => {
-      console.log('[App] selectInitialMarket() executing:', {
-        hasUser: !!user,
-        favoritesCount: favorites.length,
-        marketDataCount: marketData.length
-      });
 
       // If user is logged in and has favorites, select first favorite
       if (user && favorites.length > 0) {
@@ -180,7 +145,6 @@ function App() {
 
       // Otherwise, select first featured market
       if (marketData.length > 0) {
-        console.log('[App] No user or no favorites - selecting first featured market:', marketData[0].marketName);
         setSelectedMarket(marketData[0]);
       }
     };

--- a/housing-data-app/src/App.tsx
+++ b/housing-data-app/src/App.tsx
@@ -81,12 +81,18 @@ function App() {
   const { data: marketData, loading: dataLoading, error, loadingProgress, loadingMessage } = useMarketData();
 
   // Favorites hook
-  const { favorites, toggleFavorite, isFavorited } = useFavorites();
+  const { favorites, loading: favoritesLoading, toggleFavorite, isFavorited } = useFavorites();
 
   // Pre-selection logic: Select first favorite (if logged in with favorites) or first featured market
   useEffect(() => {
-    // Only run when data is loaded and no market is selected yet
+    // Only run when data is loaded, favorites are loaded (if user is logged in), and no market is selected yet
     if (dataLoading || selectedMarket) return;
+
+    // If user is logged in, wait for favorites to load before selecting
+    if (user && favoritesLoading) {
+      console.log('[App] Waiting for favorites to load before pre-selecting market...');
+      return;
+    }
 
     const selectInitialMarket = async () => {
       // If user is logged in and has favorites, select first favorite
@@ -143,7 +149,7 @@ function App() {
 
     selectInitialMarket();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, favorites.length, marketData.length, dataLoading]);
+  }, [user, favorites.length, marketData.length, dataLoading, favoritesLoading]);
 
   // Show loading state while checking auth (but allow app to load)
   // We'll show auth loading in the header instead of blocking the whole app

--- a/housing-data-app/src/hooks/useFavorites.ts
+++ b/housing-data-app/src/hooks/useFavorites.ts
@@ -19,10 +19,13 @@ import type { FavoriteMarket } from '../types';
 const FAVORITES_COLLECTION = 'favorites';
 
 export const useFavorites = () => {
-  const [user] = useAuthState(auth);
+  const [user, authLoading] = useAuthState(auth);
   const [favorites, setFavorites] = useState<FavoriteMarket[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [favoritesLoading, setFavoritesLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Combined loading state: true if auth is loading OR favorites are loading
+  const loading = authLoading || favoritesLoading;
 
   /**
    * Set up real-time listener for favorites
@@ -30,7 +33,7 @@ export const useFavorites = () => {
   useEffect(() => {
     if (!user) {
       setFavorites([]);
-      setLoading(false);
+      setFavoritesLoading(false);
       return;
     }
 
@@ -40,7 +43,7 @@ export const useFavorites = () => {
       { userId: user.uid }
     );
 
-    setLoading(true);
+    setFavoritesLoading(true);
     setError(null);
 
     // Create query for user's favorites
@@ -79,7 +82,7 @@ export const useFavorites = () => {
         );
 
         setFavorites(userFavorites);
-        setLoading(false);
+        setFavoritesLoading(false);
       },
       (err) => {
         console.error(
@@ -88,7 +91,7 @@ export const useFavorites = () => {
           err
         );
         setError('Failed to load favorites');
-        setLoading(false);
+        setFavoritesLoading(false);
       }
     );
 

--- a/housing-data-app/src/hooks/useFavorites.ts
+++ b/housing-data-app/src/hooks/useFavorites.ts
@@ -30,14 +30,6 @@ export const useFavorites = () => {
   // Key: We only care about favoritesInitialized when there IS a user
   const loading = authLoading || (!!user && !favoritesInitialized);
 
-  // Debug logging
-  console.log('[useFavorites] Loading state:', {
-    authLoading,
-    favoritesInitialized,
-    hasUser: !!user,
-    favoritesCount: favorites.length,
-    combinedLoading: loading
-  });
 
   /**
    * Set up real-time listener for favorites


### PR DESCRIPTION
## Summary
Fixes #3 - App now correctly pre-selects user's first favorite market instead of falling back to New York, NY on page load.

## Root Cause
Complex race condition between Firebase auth initialization, Firestore favorites loading, and market data loading:

1. App loads, auth is initializing (`user = null`, `authLoading = true`)
2. Market data finishes loading first
3. Auth completes (`user = logged in`, `authLoading = false`)
4. Pre-selection effect would run before Firestore favorites listener callback fired
5. With 0 favorites loaded, app selected fallback market (New York, NY)
6. Favorites finally arrived (3 items), but market was already selected

## Solution
Implemented a `favoritesInitialized` flag in the `useFavorites` hook:

**Key changes:**
- Added `favoritesInitialized` state (starts as `false`)
- When user logs in, Firestore listener is set up but `favoritesInitialized` stays `false`
- Only when the first `onSnapshot` callback fires (whether returning 0 or more favorites), `favoritesInitialized` becomes `true`
- Combined loading state: `authLoading || (!!user && !favoritesInitialized)`

This ensures the pre-selection logic waits for **both**:
1. Auth to finish initializing
2. First Firestore callback to complete

**Benefits:**
- Works for users with 0, 1, or many favorites
- No artificial delays or timeouts
- Leverages React's state management correctly
- Clean, declarative logic

## Testing
✅ Tested with user having 3 favorites - Los Angeles pre-selected correctly
✅ App waits for favorites to load before pre-selecting
✅ Fallback to featured market works when user has no favorites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>